### PR TITLE
Update for Fontello icon

### DIFF
--- a/templates/default/content/syndication/icon/diigo.tpl.php
+++ b/templates/default/content/syndication/icon/diigo.tpl.php
@@ -1,0 +1,1 @@
+<i class="icon-diigo"></i>


### PR DESCRIPTION
Adding a Diigo brand icon.  You need to grab the latest core update with Fontello in External for this to work.
