### PR TITLE
fix syndication slider icon

### DIFF
--- a/templates/default/content/syndication/icon/diigo.tpl.php
+++ b/templates/default/content/syndication/icon/diigo.tpl.php
@@ -1,1 +1,1 @@
-<i class="icon-diigo"></i>
+<i class="fa fa-bookmark"></i>


### PR DESCRIPTION
use FontAwesome bookmark icon (fa-bookmark) as 'icon-diigo' doesn't show any icon at all