### PR TITLE
strip HTML tags from description

### DIFF
--- a/Main.php
+++ b/Main.php
@@ -29,6 +29,7 @@
                         $title = $object->getTitleFromURL($url);
                         $tags = str_replace('#','',implode(',', $object->getTags()));
                         $desc = str_replace($object->getTags(),'',$object->description);
+                        $desc = strip_tags($desc);
                         $optionalData = array('tags'=>$tags,'desc'=>$desc);
                         $access = $object->getAccess();
                         if ($access == 'PUBLIC'){


### PR DESCRIPTION
Diigo doesn't support HTML in their descriptions (I asked the Diigo support about this).
However, it renders the HTML contained in the description **except** for the first tag. That one leaks in the UI.
So it's imho better to strip HTML altogether.